### PR TITLE
Potential fix for code scanning alert no. 7: Client-side cross-site scripting

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,8 @@
     "concurrently": "^9.1.2",
     "cross-env": "^7.0.3",
     "solid-js": "^1.9.4",
-    "tailwindcss": "^4.0.3"
+    "tailwindcss": "^4.0.3",
+    "dompurify": "^3.2.4"
   },
   "devDependencies": {
     "@neutralinojs/neu": "^11.3.1",

--- a/client/src/web/auth.html
+++ b/client/src/web/auth.html
@@ -21,6 +21,7 @@
   <script type="module">
     import Neutralino from '@neutralinojs/lib';
     import { init, events } from '@neutralinojs/lib';
+    import DOMPurify from 'dompurify';
 
     const urlParams = new URLSearchParams(window.location.search);
     const connectToken = urlParams.get('connectToken');
@@ -41,7 +42,8 @@
             if (error) {
                 try {
                     const errorObj = JSON.parse(atob(error));
-                    statusText.innerHTML = `<span class="text-red-400">Error: ${JSON.stringify(errorObj)}</span>`;
+                    const sanitizedError = DOMPurify.sanitize(JSON.stringify(errorObj));
+                    statusText.innerHTML = `<span class="text-red-400">Error: ${sanitizedError}</span>`;
                 } catch(parseError) {
                     statusText.innerHTML = '<span class="text-red-400">Error: Invalid error data received</span>';
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/tsjnsn/poe2-tradealert/security/code-scanning/7](https://github.com/tsjnsn/poe2-tradealert/security/code-scanning/7)

To fix the problem, we need to ensure that any user-provided data is properly sanitized or escaped before being inserted into the HTML. The best way to fix this issue is to use a library that provides robust escaping functions for HTML content. One such library is `DOMPurify`, which can sanitize HTML and prevent XSS attacks.

We will:
1. Import the `DOMPurify` library.
2. Use `DOMPurify` to sanitize the `errorObj` before inserting it into the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
