### PR TITLE
Resolve build issues in GitHub Actions definition

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
Update Node.js and pnpm versions in GitHub Actions workflows.

* Change Node.js version from 20 to 22 in `.github/workflows/branch-build.yml` and `.github/workflows/release.yml`.
* Change pnpm version from 8 to 10 in `.github/workflows/branch-build.yml` and `.github/workflows/release.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tsjnsn/poe2-tradealert/pull/4?shareId=00be5db5-59ee-4305-943f-773f0f6da3ac).