### PR TITLE
Add tagging step to manual prerelease workflow

### DIFF
--- a/.github/workflows/manual-prerelease.yml
+++ b/.github/workflows/manual-prerelease.yml
@@ -49,14 +49,21 @@ jobs:
           cd client
           pnpm build
 
+      - name: Create Tag
+        id: create_tag
+        run: |
+          TAG_NAME="prerelease-$(date +'%Y%m%d%H%M%S')"
+          git tag $TAG_NAME
+          git push origin $TAG_NAME
+
       - name: Create Prerelease
         id: create_prerelease
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Prerelease ${{ github.ref }}
+          tag_name: ${{ steps.create_tag.outputs.TAG_NAME }}
+          release_name: Prerelease ${{ steps.create_tag.outputs.TAG_NAME }}
           draft: false
           prerelease: true
 


### PR DESCRIPTION
Add a step to create a new tag before the "Create Prerelease" step in the `manual-prerelease.yml` workflow.

* Add a "Create Tag" step that generates a tag name with the format `prerelease-YYYYMMDDHHMMSS` and pushes it to the origin.
* Update the "Create Prerelease" step to use the newly created tag name for `tag_name` and `release_name`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tsjnsn/poe2-tradealert/pull/12?shareId=c7672391-a1e1-4a57-b9be-b35129d30344).