### PR TITLE
Fix tag_name input in manual-prerelease.yml

### DIFF
--- a/.github/workflows/manual-prerelease.yml
+++ b/.github/workflows/manual-prerelease.yml
@@ -62,8 +62,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.create_tag.outputs.TAG_NAME }}
-          release_name: Prerelease ${{ steps.create_tag.outputs.TAG_NAME }}
+          tag_name: ${{ steps.create_tag.outputs.tag_name }}
+          release_name: Prerelease ${{ steps.create_tag.outputs.tag_name }}
           draft: false
           prerelease: true
 


### PR DESCRIPTION
Update the `tag_name` input in the pre-release GitHub action.

* Change the `tag_name` input in the `actions/create-release@v1` step to `${{ steps.create_tag.outputs.tag_name }}` in `.github/workflows/manual-prerelease.yml`
* Update the `release_name` input to use `${{ steps.create_tag.outputs.tag_name }}` in the same step

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tsjnsn/poe2-tradealert/pull/13?shareId=35cf0c37-d41d-4707-88d8-9f61c7d167d9).