### PR TITLE
Update the tag_name input in the pre-release GitHub action

### DIFF
--- a/.github/workflows/manual-prerelease.yml
+++ b/.github/workflows/manual-prerelease.yml
@@ -62,8 +62,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.create_tag.outputs.TAG_NAME }}
-          release_name: Prerelease ${{ steps.create_tag.outputs.TAG_NAME }}
+          tag_name: ${{ steps.create_tag.outputs.tag_name }}
+          release_name: ${{ steps.create_tag.outputs.tag_name }}
           draft: false
           prerelease: true
 


### PR DESCRIPTION
Update the `tag_name` and `release_name` inputs in the `actions/create-release@v1` step in `.github/workflows/manual-prerelease.yml`.

* Change `tag_name` input to `${{ steps.create_tag.outputs.tag_name }}`
* Change `release_name` input to `${{ steps.create_tag.outputs.tag_name }}`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tsjnsn/poe2-tradealert/pull/15?shareId=457bd2d2-eb3c-4a79-8ae1-e35d008a17ff).